### PR TITLE
add option to create_many for excluding created_at

### DIFF
--- a/lib/bulk_data_methods/bulk_methods_mixin.rb
+++ b/lib/bulk_data_methods/bulk_methods_mixin.rb
@@ -51,6 +51,7 @@ module BulkMethodsMixin
     return [] if rows.blank?
     options[:slice_size] = 1000 unless options.has_key?(:slice_size)
     options[:check_consistency] = true unless options.has_key?(:check_consistency)
+    options[:add_created_at] = true unless options.has_key?(:add_created_at)
     returning_clause = ""
     if options[:returning]
       if options[:returning].is_a? Array
@@ -75,7 +76,9 @@ module BulkMethodsMixin
       row[:id] ||= row_ids.shift
     end.each do |row|
       # set :created_at if need be
-      row[:created_at] ||= created_at_value
+      if options[:add_created_at]
+        row[:created_at] ||= created_at_value
+      end
     end.group_by do |row|
       respond_to?(:partition_table_name) ? partition_table_name(*partition_key_values(row)) : table_name
     end.each do |table_name, rows_for_table|


### PR DESCRIPTION
I have some use cases which exclude the created_at column. create_many automatically adds this column and attempts to insert it for each row, breaking if it's not in the data model.

This patch allows for the option :add_created_at to be set to false to skip adding created_at.